### PR TITLE
Improve error stack trace from trepl.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -615,10 +615,14 @@ function repl()
          local err
          if not (line:find(';%s-$') or line:find('^%s-print')) then
             -- Try to compile statement with "return", to auto-print
-            local parsed = loadstring('local f = function() return '..line..' end local res = {f()} print(unpack(res)) table.insert(_RESULTS,res[1])')
+            local parsed = loadstring('local f = function() return '..line..' end')
             if parsed then
-               local ok,err = xpcall(parsed, traceback)
-               if not ok then
+               local parsed = loadstring('_RESULT={'..line..'}')
+               local ok,err=xpcall(parsed, traceback)
+               if ok then
+                  print(unpack(_RESULT))
+                  table.insert(_RESULTS,_RESULT[1])
+               else
                   print(err)
                end
                done = true


### PR DESCRIPTION
trepl does a trick to print the results of commands, but this trick
confuses the traceback.

Before:

  th> a=torch.Tensor(1,2)
  th> a:size(3)
  [string "local f = function() return a:size(3) end loc..."]:1: bad argument #2 to 'f' (out of range)
  stack traceback:
    [C]: in function 'f'
    [string "local f = function() return a:size(3) end loc..."]:1: in main chunk
    [C]: in function 'xpcall'
    ...r/git/torch-distro2/install/share/lua/5.1/trepl/init.lua:620: in function 'repl'
    ...ch-distro2/install/lib/luarocks/rocks/trepl/scm-1/bin/th:185: in main chunk
    [C]: at 0x004057d0

After:

  th> a=torch.Tensor(1,2)
  th> a:size(3)
  [string "_ = a:size(3)"]:1: bad argument #1 to 'size' (out of range)
  stack traceback:
    [C]: in function 'size'
    [string "_ = a:size(3)"]:1: in main chunk
    [C]: in function 'xpcall'
    ...r/git/torch-distro2/install/share/lua/5.1/trepl/init.lua:623: in function 'repl'
    ...ch-distro2/install/lib/luarocks/rocks/trepl/scm-1/bin/th:185: in main chunk
    [C]: at 0x004057d0