### PR TITLE
Allow user to control whether to confirm exiting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -562,9 +562,14 @@ function repl()
 
       -- Interupt?
       if not line or line == 'exit' then
-         io.write('Do you really want to exit ([y]/n)? ') io.flush()
-         local line = io.read('*l')
-         if line == '' or line:lower() == 'y' then
+         local input = ''
+         if not path.isfile(paths.home .. '/.trepl_noaskexit') then
+            io.write('Do you really want to exit ([y]/n)? ') io.flush()
+            input = io.read('*l')
+         elseif line == nil then
+            io.write('\n') io.flush()
+         end
+         if input == '' or input:lower() == 'y' then
             os.exit()
          end
       end


### PR DESCRIPTION
Allows the user to let the trepl exit without asking whether this is what the user wants or not, by creating a file `~/.trepl_noaskexit`.  For example, this allows `ctrl+d` to have the same behaviour as in Ruby, Python, et al.