### PR TITLE
readthedocs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -194,4 +194,3 @@ will be printed every second - step #3
 will be printed every second - step #20
 will be printed every second - step #21
 ```
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: trepl
+theme : simplex
+repo_url : https://github.com/torch/trepl
+use_directory_urls : false
+markdown_extensions: [extra]
+docs_dir : doc
+pages:
+- [index.md, TREPL]


### PR DESCRIPTION
This PR gives us this : http://trepl.readthedocs.org/en/rtd/index.html .
I DID NOT refactor the README into different files since the README is very small.
Instead I just copy-pasted the README to doc/index.md. So doc modifications in the future should do the same. I known this isn't perfection, but the alternative is to have the README.md have a link to the index.md, or to split it into files.