### PR TITLE
skip readline when HOME is not present in environment

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -514,7 +514,7 @@ _LAST = ''
 -- Readline:
 local readline_ok,readline = pcall(require,'readline')
 local nextline,saveline
-if readline_ok then
+if readline_ok and (os.getenv('HOME') or os.getenv('USERPROFILE')) ~= nil then
    -- Readline found:
    local history = (os.getenv('HOME') or os.getenv('USERPROFILE')) .. '/.luahistory'
    readline.setup()


### PR DESCRIPTION
this is the error when I was running th under a shell that doesn't have HOME set. (specifically supervisord)
```
luajit: init.lua:519: attempt to concatenate a nil value
stack traceback:
        init.lua:519: in main chunk
        [C]: at 0x004050b0
```
It's ok to call luajit directly, but some Torch code expects Penlight library (like 'path'). So it might helps just skip the readline loading and still preserves the same lua environment.