### PR TITLE
replacing os.exit with return so that lua state is properly closed

### DIFF
--- a/th
+++ b/th
@@ -52,7 +52,7 @@ for _,arg in ipairs(parg) do
          -- help
          if shortopt == 'h' or option == 'help' then
             print(help)
-            os.exit()
+	    return
          elseif shortopt == 'i' or option == 'interactive' then
             interactive = true
          elseif shortopt == 'e' then
@@ -73,7 +73,7 @@ for _,arg in ipairs(parg) do
             -- unknown
             print('Error: unrecognized flag --' .. option)
             print(help)
-            os.exit()
+	    return
          end
       else
          -- exec program
@@ -119,10 +119,10 @@ if statement then
    local ok,res = pcall(s)
    if not ok then
       print(res)
-      os.exit()
+      return
    end
    -- quit by default
-   if not interactive then os.exit() end
+   if not interactive then return end
 end
 
 -- run program
@@ -132,7 +132,7 @@ if run then
    -- run
    dofile(run)
    -- quit by default
-   if not interactive then os.exit() end
+   if not interactive then return end
 end
 
 -- start repl


### PR DESCRIPTION
As first reported by @mavenlin , the finalizers are not properly called at the end of a script when using th.
https://github.com/torch/luajit-rocks/issues/16

A simple test case is:

```lua
require 'torch'
torch.Tensor.__gc = function() print('gc') end
tensor = torch.Tensor(10)
```

```bash
$ luajit b.lua
gc
$

$ th b.lua
$
```

After investigating, it is because we call os.exit() after a bunch of cases, rather than letting luajit finalize the state with lua_close https://github.com/LuaJIT/LuaJIT/blob/master/src/luajit.c#L568

Changing the "os.exit()" to simple "return" fixes the issue, as it properly returns control to luajit which can call finalizers.