### PR TITLE
disabling colors if terminal doesn't support colors

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -37,6 +37,21 @@ function noColors()
    end
 end
 
+local cutils = require 'treplutils'
+
+-- best effort isWindows. Not robust
+local function isWindows()
+   return type(package) == 'table' and
+      type(package.config) == 'string' and
+      package.config:sub(1,1) == '\\'
+end
+
+if isWindows()
+   or (not cutils.isatty())
+or (os.execute('tput colors >/dev/null') ~= 0) then
+   noColors()
+end
+
 -- Help string:
 local selfhelp =  [[
   ______             __

--- a/readline.c
+++ b/readline.c
@@ -6,6 +6,7 @@
 #include "lualib.h"
 #include <readline/readline.h>
 #include <readline/history.h>
+#include <ctype.h>
 
 #if LUA_VERSION_NUM == 501
 # define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)

--- a/trepl-scm-1.rockspec
+++ b/trepl-scm-1.rockspec
@@ -29,6 +29,9 @@ build = {
       ['readline'] = {
          sources = {'readline.c'},
          libraries = {'readline'}
+      },
+      ['treplutils'] = {
+         sources = {'utils.c'},
       }
    },
    platforms = {

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,41 @@
+#include "lua.h"
+#include "lauxlib.h"
+#include "lualib.h"
+
+#if LUA_VERSION_NUM == 501
+# define lua_pushglobaltable(L) lua_pushvalue(L, LUA_GLOBALSINDEX)
+# define luaL_setfuncs(L, libs, _) luaL_register(L, NULL, libs)
+#else
+# define lua_strlen lua_rawlen
+#endif
+
+#if defined(_WIN32) || defined(LUA_WIN)
+
+int treplutils_isatty(lua_State *L)
+{
+  lua_pushboolean(L, 0);
+  return 1;
+}
+
+#else
+
+#include <unistd.h>
+
+int treplutils_isatty(lua_State *L)
+{
+  lua_pushboolean(L, isatty(1));
+  return 1;
+}
+
+#endif
+
+static const struct luaL_Reg utils[] = {
+  {"isatty", treplutils_isatty},
+  {NULL, NULL}
+};
+
+int luaopen_treplutils(lua_State *L) {
+  lua_newtable(L);
+  luaL_setfuncs(L, utils, 0);
+  return 1;
+}


### PR DESCRIPTION
fixes #34 

Supports windows (hopefully, untested)

When piping to files, and in zbs-torch, color characters are no longer outputted.

Old behavior:
```bash
th -e "print('hello world')" | more
ESC[0mhello worldESC[0m
```

New behavior:
```bash
th -e "print('hello world')" | more
hello world
```