### PR TITLE
xpcall + debug stack around library loading in th

### DIFF
--- a/th
+++ b/th
@@ -2,6 +2,17 @@
 
 loadstring = loadstring or load -- for lua 5.2 compat
 
+-- Tracekback (error printout)
+local function traceback(message)
+   local tp = type(message)
+   if tp ~= "string" and tp ~= "number" then return message end
+   local debug = _G.debug
+   if type(debug) ~= "table" then return message end
+   local tb = debug.traceback
+   if type(tb) ~= "function" then return message end
+   return tb(message)
+end
+
 -- help
 local help = [==[
 Usage: th [options] [script.lua [arguments]]
@@ -34,9 +45,10 @@ for _,arg in ipairs(parg) do
    end
    -- load libraries
    if lib then
-      local ok = pcall(require,lib)
+      local ok, err = xpcall(function() require(lib) end, traceback)
       if not ok then
          print('could not load ' .. lib .. ', skipping')
+	 print(err)
       end
    elseif progargs then
       -- program args


### PR DESCRIPTION
A much needed PR, especially to help us debug user issues.

Without this, we are constantly asking users to also give us the output for `luajit -l[libname]` which is annoying and time-consuming.

```bash
th -ldummylib
could not load dummylib, skipping
...inso/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:48: module 'dummylib' not found:No LuaRocks module found for dummylib
        no field package.preload['dummylib']
        no file '/Users/chinso/.luarocks/share/lua/5.1/dummylib.lua'
        no file '/Users/chinso/.luarocks/share/lua/5.1/dummylib/init.lua'
        no file '/Users/chinso/torch/install/share/lua/5.1/dummylib.lua'
        no file '/Users/chinso/torch/install/share/lua/5.1/dummylib/init.lua'
        no file './dummylib.lua'
        no file '/Users/chinso/torch/install/share/luajit-2.1.0-alpha/dummylib.lua'
        no file '/usr/local/share/lua/5.1/dummylib.lua'
        no file '/usr/local/share/lua/5.1/dummylib/init.lua'
        no file '/Users/chinso/.luarocks/lib/lua/5.1/dummylib.so'
        no file '/Users/chinso/torch/install/lib/lua/5.1/dummylib.so'
        no file './dummylib.so'
        no file '/usr/local/lib/lua/5.1/dummylib.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
        [C]: in function 'require'
        ...inso/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:48: in function <...inso/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:48>
        [C]: in function 'xpcall'
        ...inso/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:48: in main chunk
        [C]: at 0x010d087bc0

  ______             __   |  Torch7
 /_  __/__  ________/ /   |  Scientific computing for Lua.
  / / / _ \/ __/ __/ _ \  |  Type ? for help
 /_/  \___/_/  \__/_//_/  |  https://github.com/torch
                          |  http://torch.ch

th>
```