### PR TITLE
Enable heap tracking by default.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -688,5 +688,8 @@ for k,v in pairs(_G) do
    _G._preloaded_[k] = true
 end
 
+-- Enable heap tracking
+torch.setheaptracking(true)
+
 -- return repl, just call it to start it!
 return repl


### PR DESCRIPTION
-> this is proven enough, and eliminates the need for
   manual GC-ing.