### PR TITLE
Allow quitting with double Ctrl+D

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -584,7 +584,7 @@ function repl()
       if not line or line == 'exit' then
          io.write('Do you really want to exit ([y]/n)? ') io.flush()
          local line = io.read('*l')
-         if line == '' or line:lower() == 'y' then
+         if not line or line == '' or line:lower() == 'y' then
             os.exit()
          end
       end


### PR DESCRIPTION
I'm used to this feature from IPython/Jupyter and since here you also quit on empty string, I see no harm?

Without this change, doing double Ctrl+D would get the following, which also quits :smile: 

```
th> Do you really want to exit ([y]/n)? /home.local/lucas/inst/src/torch/install/bin/luajit: ...ucas/inst/src/torch/install/share/lua/5.1/trepl/init.lua:587: attempt to index local 'line' (a nil value)
stack traceback:
	...ucas/inst/src/torch/install/share/lua/5.1/trepl/init.lua:587: in function 'repl'
	.../src/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:199: in main chunk
	[C]: at 0x00406670
```