### PR TITLE
Fix running in torch-less env with stub for torch.setheaptracking()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -132,7 +132,8 @@ local selfhelp =  [[
 -- If no Torch:
 if not torch then
    torch = {
-      typename = function() return '' end
+      typename = function() return '' end,
+      setheaptracking = function() end
    }
 end
 


### PR DESCRIPTION
This commit stubs out torch.setheaptracking(), so trepl can be run in a torch-less environment. It fixes the following error:

```
$ th
/usr/bin/lua5.1: /usr/share/lua/5.1/trepl/init.lua:692: attempt to call field 'setheaptracking' (a nil value)
stack traceback:
    /usr/share/lua/5.1/trepl/init.lua:692: in main chunk
    [C]: in function 'require'
    /usr/lib/luarocks/rocks-5.1/trepl/scm-1/bin/th:104: in main chunk
    [C]: ?
$
```