### PR TITLE
init.lua: trivial enhancement on exit

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -586,6 +586,7 @@ function repl()
          io.write('Do you really want to exit ([y]/n)? ') io.flush()
          local line = io.read('*l')
          if not line or line == '' or line:lower() == 'y' then
+            if not line then print('') end
             os.exit()
          end
       end


### PR DESCRIPTION
Generally the original code is fine when user exit th with `Ctrl^D`, `y` and ENTER. However when a user exits th with `Ctrl^D Ctrl^D` then no `newline` is printed, in this case shell's PS1 will be printed to an ugly place.

This commit can fix this issue.