### PR TITLE
fix for windows with wineditline

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -46,10 +46,15 @@ local function isWindows()
       package.config:sub(1,1) == '\\'
 end
 
-if isWindows() or (not cutils.isatty()) then
+local hasTPut = true -- default true for non windows
+if isWindows() then
+  hasTPut = sys.fexecute('where tput'):find('tput')
+end
+
+if not hasTPut or not cutils.isatty() then
    noColors()
 else
-   local outp = os.execute('tput colors >/dev/null')
+   local outp = os.execute('tput colors >' .. (isWindows() and 'NUL' or '/dev/null'))
    if type(outp) == 'boolean' and not outp then
       noColors()
    elseif type(outp) == 'number' and outp ~= 0 then
@@ -519,6 +524,10 @@ local aliases = [[
    alias la='ls -ahF';
    alias lla='ls -lahF';
 ]]
+
+if isWindows() then
+   aliases = ""
+end
 
 -- Penlight
 pcall(require,'pl')

--- a/readline.c
+++ b/readline.c
@@ -4,8 +4,12 @@
 #include "lua.h"
 #include "lauxlib.h"
 #include "lualib.h"
+#ifndef WinEditLine
 #include <readline/readline.h>
 #include <readline/history.h>
+#else
+#include <editline/readline.h>
+#endif
 #include <ctype.h>
 
 #if LUA_VERSION_NUM == 501
@@ -260,12 +264,16 @@ static int f_setup(lua_State *L)
   /* Break words at every non-identifier character except '.' and ':'. */
   rl_completer_word_break_characters =
     "\t\r\n !\"#$%&'()*+,-/;<=>?@[\\]^`{|}~";
+#ifndef WinEditLine
   rl_completer_quote_characters = "\"'";
+#endif
 /* #if RL_READLINE_VERSION < 0x0600 */
   rl_completion_append_character = '\0';
 /* #endif */
   rl_attempted_completion_function = lua_rl_complete;
+#ifndef WinEditLine
   rl_initialize();
+#endif
 
   return 0;
 }

--- a/trepl-scm-1.rockspec
+++ b/trepl-scm-1.rockspec
@@ -40,10 +40,10 @@ build = {
 		    ['readline'] = {
                sources = {'readline.c'},
                libraries = {'readline'},
-			   defines = {"USE_READLINE_STATIC"},
-               incdirs = {"windows"},
-               libdirs = {"windows"},
-               libraries = {'readline-win'}
+               defines = {"WinEditLine"},
+               incdirs = {"..\\..\\win-files\\3rd\\wineditline-2.101\\include"},
+               libdirs = {"..\\..\\win-files\\3rd\\wineditline-2.101\\lib64"},
+               libraries = {'edit_static', 'user32'}
 			}
 		 }
 	  }

--- a/utils.c
+++ b/utils.c
@@ -13,7 +13,7 @@
 
 int treplutils_isatty(lua_State *L)
 {
-  lua_pushboolean(L, 0);
+  lua_pushboolean(L, _isatty(1));
   return 1;
 }
 


### PR DESCRIPTION
Hi,

(1) download [wineditline](https://sourceforge.net/projects/mingweditline/files/latest), unzip
(2) cd wineditline*
(3) cmake -E make_directory build && cd build && cmake .. -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=..\ && nmake install
x64 lib will be in lib64, x64 dll will be in bin64. Note, the prebuilt 64bit dll, lib are actually targeted for x86 which will not work if you are trying to use trepl for x64.

Thanks,