### PR TITLE
Allow executing file before trepl starts

### DIFF
--- a/th
+++ b/th
@@ -104,6 +104,11 @@ end
 local repl = require 'trepl'
 local col = require 'trepl.colorize'
 
+-- load startup file
+if os.getenv('TREPLSTARTUP') and not (interactive or statement) then
+    dofile(os.getenv('TREPLSTARTUP'))
+end
+
 -- load gfx env?
 if lgfx then
    local ok = pcall(require, 'gfx.js')


### PR DESCRIPTION
Python has it. Why don't we? This PR allows users to specify a `TREPLSTARTUP` file that is run before the rest of trepl (unless in interactive interactive mode, as is Python's convention).